### PR TITLE
Update SimpleFSM.cpp

### DIFF
--- a/src/SimpleFSM.cpp
+++ b/src/SimpleFSM.cpp
@@ -302,7 +302,10 @@ bool SimpleFSM::_isTimeForRun(unsigned long now, int interval) {
 
 void SimpleFSM::_handleTimedEvents(unsigned long now) {
   for (int i = 0; i < num_timed; i++) {
-    if (timed[i].from != current_state) continue;
+    if (timed[i].from != current_state) {
+      timed[i].start = 0; // Reset the timers of not currently runing states
+      continue;
+    }
     // start the transition timer 
     if (timed[i].start == 0) {
       timed[i].start = now;


### PR DESCRIPTION
Bug fix for timedTransition miscalculating the time for the state transition:
- the current state with timed transition is untouched, 
- all the other states with timed transitions are having their timers reset, as the change of state can be triggered by other means, effectively not allowing the handleTimedEvents() to zero the timer,

It is fixing this bug #25  